### PR TITLE
catch exception in filter thread runner

### DIFF
--- a/erc20token/sdk.py
+++ b/erc20token/sdk.py
@@ -628,6 +628,10 @@ class FilterManager(object):
                         logging.warning('filter {} has expired, recreating'.format(filtr.filter_id))
                         new_filter = self.web3.eth.filter(filter_params)
                         filtr.filter_id = new_filter.filter_id
+                        continue
+                    logging.exception(ve)
+                except Exception as e:
+                    logging.exception(e)
         return _runner
 
     def remove_filters(self):

--- a/erc20token/utils.py
+++ b/erc20token/utils.py
@@ -3,7 +3,11 @@
 # Copyright (C) 2017 Kin Foundation
 
 import json
+import os
 import sys
+
+import logging
+logger = logging.getLogger(__name__)
 
 
 def create_keyfile(private_key, password, filename):
@@ -16,14 +20,21 @@ def create_keyfile(private_key, password, filename):
 
     :param str filename: keyfile path
 
-    :raises: NotImplementedError: when using Python 2
+    :raises: NotImplementedError: when using Python 3
     """
     if sys.version_info.major >= 3:
         raise NotImplementedError('keyfile creation is only supported in python2')
     from ethereum.tools import keys
     keyfile_json = keys.make_keystore_json(private_key.encode(), password, kdf='scrypt')
-    with open(filename, 'w+') as f:
-        json.dump(keyfile_json, f)
+    try:
+        oldumask = os.umask(0)
+        fd = os.open(filename, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "w") as f:
+            json.dump(keyfile_json, f)
+    except IOError as e:
+        logger.exception(e)
+    finally:
+        os.umask(oldumask)
 
 
 def load_keyfile(keyfile, password):
@@ -36,7 +47,7 @@ def load_keyfile(keyfile, password):
     :returns: private key
     :rtype: str
 
-    :raises: NotImplementedError: when using Python 2
+    :raises: NotImplementedError: when using Python 3
     :raises: IOError: if the file is not found
     :raises: ValueError: if the keyfile format is invalid
     """
@@ -44,8 +55,8 @@ def load_keyfile(keyfile, password):
         raise NotImplementedError('keyfile usage is only supported in python2')
     with open(keyfile, 'r') as f:
         keystore = json.load(f)
-        from ethereum.tools import keys as ekeys
-        if not ekeys.check_keystore_json(keystore):
+        from ethereum.tools import keys as keys
+        if not keys.check_keystore_json(keystore):
             raise ValueError('invalid keyfile format')
-        return ekeys.decode_keystore_json(keystore, password)
+        return keys.decode_keystore_json(keystore, password)
 

--- a/test/test_sdk.py
+++ b/test/test_sdk.py
@@ -139,7 +139,8 @@ def test_create_fail_keyfile(testnet):
     with pytest.raises(erc20token.SdkConfigurationError, match="cannot load keyfile: invalid keyfile format"):
         erc20token.SDK(provider_endpoint_uri=testnet.provider_endpoint_uri, contract_address=testnet.address,
                        contract_abi=testnet.contract_abi, keyfile=TEST_KEYFILE)
-
+    os.remove(TEST_KEYFILE)
+    
     # good keyfile, wrong password
     erc20token.create_keyfile(testnet.private_key, TEST_PASSWORD, TEST_KEYFILE)
     with pytest.raises(erc20token.SdkConfigurationError, match='cannot load keyfile: MAC mismatch. Password incorrect?'):


### PR DESCRIPTION
keyfile is now created with tighter permissions as suggested in https://github.com/kinfoundation/kin-sdk-python/issues/12