### PR TITLE
fix(provider): import error 'make_post_request'

### DIFF
--- a/erc20token/provider.py
+++ b/erc20token/provider.py
@@ -5,7 +5,11 @@
 import backoff
 import requests
 from web3 import HTTPProvider
-from web3.utils.compat import make_post_request
+
+try:
+    from web3.utils.request import make_post_request
+except ImportError: 
+    from web3.utils.compat import make_post_request
 
 
 class RetryHTTPProvider(HTTPProvider):


### PR DESCRIPTION
The latest version of `web3` installed by this library has moved `make_post_reqeust` to `web3.util.request`. 

We try to import from the new location with a fallback to old one.